### PR TITLE
Fix build when using brew libtool

### DIFF
--- a/build-native.sh
+++ b/build-native.sh
@@ -13,8 +13,6 @@ BUILD_TYPE=Debug
 TARGET_ARCH=x64
 HOST_OS=Linux
 FILE_EXTENSION=".so"
-#with the given install script this works on macs, need to override glibtoolize
-export LIBTOOLIZE="libtoolize"
 
 case $(uname -s) in
     Darwin)


### PR DESCRIPTION
The version installed from homebrew is called glibtoolize, so we don't
need this export, the underlying autogen.sh is going to do the right
thing.