### PR TITLE
Add arg to skip git submodule calls

### DIFF
--- a/build-native.cmd
+++ b/build-native.cmd
@@ -4,6 +4,7 @@
 set BUILD_TYPE=Debug
 set __TargetArch=x64
 set __TargetOS=Windows_NT
+set __SkipGit=false
 
 :Arg_Loop
 if [%1] == [] goto :Args_Parsed
@@ -21,6 +22,7 @@ if /i [%1] == [--platform] (
   echo "Unknown Platform: '%1'"
   exit /b 1
 )
+if /i [%1] == [--skip-git] ( set __SkipGit=true&&shift&&goto Arg_Loop )
 echo "Unknown Argument: '%1'
 exit /b 1
 
@@ -34,8 +36,10 @@ set __buildOutputDir=%~dp0\src\libuv\%BUILD_TYPE%
 set GYP_MSVS_VERSION=2015
 
 :: update sub module if required
-git submodule init
-git submodule update
+if "%__SkipGit%"=="false" (
+  git submodule init
+  git submodule update
+)
 
 :: Determine the tools version to pass to cmake/msbuild
 if not defined VisualStudioVersion (

--- a/build-native.sh
+++ b/build-native.sh
@@ -67,6 +67,9 @@ while :; do
                 ;;
             esac
             ;;
+        --skip-git)
+            SKIP_GIT=true
+            ;;
         *)
             echo "Unknown Argument '$1'"
             exit 1
@@ -79,8 +82,10 @@ done
 BINARY_DIR="$BINARY_ROOT/$TARGET_OS.$TARGET_ARCH.$BUILD_TYPE"
 OBJECT_DIR="$OBJECT_ROOT/$TARGET_OS.$TARGET_ARCH.$BUILD_TYPE"
 
-git submodule init
-git submodule update
+if [ -z "$SKIP_GIT" ]; then
+    git submodule init
+    git submodule update
+fi
 
 mkdir -p $BINARY_DIR
 mkdir -p $OBJECT_DIR

--- a/build-packages.cmd
+++ b/build-packages.cmd
@@ -2,8 +2,10 @@
 @echo off
 setlocal
 
+set "__ProjectDir=%~dp0"
 set __PackageRID=win7-x64
 set BUILD_TYPE=Debug
+set __BuildVersionFile=
 
 :Arg_Loop
 if [%1] == [] goto :Args_Done
@@ -14,6 +16,7 @@ if /i [%1] == [--configuration] (
   exit /b 1
 )
 if /i [%1] == [--runtime-id] ( set __PackageRID=%2&&shift&&shift&&goto Arg_Loop )
+if /i [%1] == [--build-version-file] ( set __BuildVersionFile=%2&&shift&&shift&&goto Arg_Loop )
 echo "Unknown Argument: '%1'
 exit /b 1
 
@@ -30,9 +33,9 @@ if not defined VisualStudioVersion (
 )
 
 :Run
-call %~dp0init-tools.cmd
+call %__ProjectDir%init-tools.cmd
 if NOT [%ERRORLEVEL%]==[0] exit /b 1
 
 :PackageBuild
-call %~dp0Tools\msbuild.cmd /flp:v=diag "%~dp0pkg\Libuv\Libuv.builds" /p:PackageRID=%__PackageRID% /p:ConfigurationGroup=%BUILD_TYPE%
+call %__ProjectDir%Tools\msbuild.cmd /flp:v=diag "%__ProjectDir%pkg\Libuv\Libuv.builds" /p:PackageRID=%__PackageRID% /p:ConfigurationGroup=%BUILD_TYPE% /p:BuildVersionFile=%__BuildVersionFile%
 if NOT [%ERRORLEVEL%]==[0] exit /b 1

--- a/build-packages.sh
+++ b/build-packages.sh
@@ -32,6 +32,10 @@ while :; do
             shift
             PACKAGE_RID=$(echo $1 | awk '{print tolower($0)}')
             ;;
+        --build-version-file)
+            shift
+            BUILD_VERSION_FILE="$1"
+            ;;
         *)
             echo "Unknown Argument '$1'"
             exit 1
@@ -42,4 +46,4 @@ while :; do
 done
 
 "$SCRIPT_ROOT/init-tools.sh"
-"$SCRIPT_ROOT/Tools/msbuild.sh" /flp:v=diag "$SCRIPT_ROOT/pkg/Libuv/Libuv.builds" /p:PackageRID=$PACKAGE_RID /p:ConfigurationGroup=$BUILD_TYPE
+"$SCRIPT_ROOT/Tools/msbuild.sh" /flp:v=diag "$SCRIPT_ROOT/pkg/Libuv/Libuv.builds" /p:PackageRID=$PACKAGE_RID /p:ConfigurationGroup=$BUILD_TYPE /p:BuildVersionFile=$BUILD_VERSION_FILE


### PR DESCRIPTION
Makes it so we can pass `--skip-git` to disable the submodule update calls in the build-native scripts. @ellismg 

I haven't tested the `sh` side yet. This PR is an FYI about this change so far.